### PR TITLE
Fix post generation using pandoc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM node:18-alpine
 
 LABEL maintainer="DevOps Academy - Pasima"
 
-# Install serve and markdown-html
-RUN npm install -g serve markdown-html
+# Install pandoc and serve
+RUN apk add --no-cache pandoc \
+    && npm install -g serve
 
 # Create working directories
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project builds a sleek, modern, and fully Dockerized static site using:
 
 - Markdown for content
 - Custom HTML templates
-- `markdown-html` + `serve` for conversion & hosting
+- `pandoc` + `serve` for conversion & hosting
 - A clean DevOps-style UI
 
 Perfect for students, bootcamps, or professionals who want to showcase tech writeups in style.
@@ -98,7 +98,7 @@ docker run -d -p 8080:8080 devops-blog
 | --------------- | -------------------------------- |
 | `Docker`        | Containerize the site generator  |
 | `Node.js`       | Used inside container (alpine)   |
-| `markdown-html` | Converts `.md` to HTML           |
+| `pandoc`        | Converts `.md` to HTML           |
 | `serve`         | Static server for `/public` HTML |
 | `bash` + `sed`  | Template injection logic         |
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ for mdfile in posts/*.md; do
 
   echo "  • $base → $outfile (Title: $title)"
 
-  npx markdown-html "$mdfile" > "public/${base}.content.html"
+  pandoc "$mdfile" -f markdown -t html > "public/${base}.content.html"
 
   sed "s|<!-- POST_TITLE -->|$title|g" templates/post_template.html | \
     sed "/<!-- POST_BODY -->/{


### PR DESCRIPTION
## Summary
- convert Markdown posts with `pandoc` instead of `npx markdown-html`
- install `pandoc` in Dockerfile
- update README to reflect pandoc usage

## Testing
- `sh entrypoint.sh`

